### PR TITLE
fix(frontend): install missing dependencies in start_frontend.sh

### DIFF
--- a/start_frontend.sh
+++ b/start_frontend.sh
@@ -5,4 +5,7 @@ cd frontend/fw-manus-ui
 
 # Start the development server
 echo "Starting React development server..."
+# Install dependencies if not already done
+npm install
+# Start the development server
 npm run dev


### PR DESCRIPTION
fix(frontend): install missing dependencies in start_frontend.sh

The frontend startup script was missing necessary dependency installation,
causing the app to fail on first run. This commit adds `npm install` to 
ensure all required packages are installed before starting the frontend 
development server.

